### PR TITLE
Add footer tests

### DIFF
--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -26,7 +26,28 @@ it('should display corresponding information', () => {
 
   cy.contains('footer', 'Created with')
   cy.contains('footer', 'by Mario')
+
+  cy.findByRole('link', { name: /mario/i }).should(
+    'have.attr',
+    'href',
+    'https://mario.dev/'
+  )
+
+  cy.findByRole('link', {
+    name: /octoclairvoyant repository on github/i,
+  }).should(
+    'have.attr',
+    'href',
+    'https://github.com/octoclairvoyant/octoclairvoyant-webapp'
+  )
+
+  cy.findByRole('img', { name: /powered by vercel logo/i })
+  // Find way to make this query below work
+  // .should('have.attr', 'src')
+  // .should('include', 'powered-by-vercel')
 })
+
+// TODO: Add test that checks if the Vercel img has the correct href, should be: https://vercel.com/?utm_source=octoclairvoyant-team&utm_campaign=oss
 
 it('should have a working link to comparator page', () => {
   cy.visit('/')


### PR DESCRIPTION
## Changes

- Check page shows link to Mario's homepage
- Check page shows link to Octoclairvoyant's GitHub repository
- Check page shows Vercel badge

## Context

This PR adds some more tests to check if we're actually displaying the wanted items in our footer. Right now it uses find by role, but it's not limited to checking the `<footer>` section, so it's really checking if the page shows the item, not if the footer specifically contains the items.

I need some help to get the Vercel badge test working properly. I cannot get it to accurately find the `src` to test that it uses the correct SVG image. I also cannot test the `href` that comes with the Vercel badge.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [x] Adding new tests or adjusting existing tests
- [ ] Testing manually
