### PR TITLE
Reuse .nvmrc in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ permissions:
   contents: read
   actions: write
 
-env:
-  NODE_VERSION: '14'
-
 jobs:
   lint:
     name: Code Linting
@@ -24,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458 # renovate: tag=v2.5.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -45,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458 # renovate: tag=v2.5.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -66,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458 # renovate: tag=v2.5.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -97,7 +94,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458 # renovate: tag=v2.5.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Changes

- use `node-version-file` to set Node version in CI from `.nvmrc` instead of harcoding the version in the CI file. This makes the Node version used easier to maintain since now the source of truth is the `.nvmrc` file.

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Relates to #599 

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
