### PR TITLE
Set new default colors

### DIFF
--- a/src/components/BlockQuote.tsx
+++ b/src/components/BlockQuote.tsx
@@ -7,7 +7,7 @@ const BlockQuote = (props: BoxProps) => (
     px={4}
     borderLeftWidth={4}
     borderLeftColor="coolGray.200"
-    color="tertiaryTextLightmode"
+    color="tertiaryText"
     {...props}
   />
 )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,17 +23,19 @@ const Header = (props: BoxProps) => {
           <Flex alignItems="center">
             <RouteLink
               href="/"
-              borderBottomWidth={4}
-              borderBottomColor="transparent"
+              textDecorationLine="underline"
+              textDecorationThickness="4px"
+              textUnderlineOffset="2px"
+              textDecorationColor="transparent"
               _hover={{
-                borderBottomColor: 'primary.700',
+                textDecorationColor: 'primary.700',
               }}
               _focus={{
                 boxShadow: 'outline',
-                borderBottomColor: 'primary.700',
+                textDecorationColor: 'primary.700',
               }}
               _active={{
-                borderBottomColor: 'primary.900',
+                textDecorationColor: 'primary.900',
               }}
             >
               <HStack spacing={2}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -44,7 +44,7 @@ const Header = (props: BoxProps) => {
                 </Box>
                 <Heading
                   as="h1"
-                  color="primaryTextLightmode"
+                  color="primaryText"
                   letterSpacing="tight"
                   fontWeight="black"
                   fontSize={{ base: '16px', sm: '36px' }}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ const Header = (props: BoxProps) => {
       {...props}
       borderTopWidth={{ base: '4px', sm: '8px' }}
       borderColor="primary.700"
+      bgColor="primaryBg"
     >
       <Container variant="fluid" py={5}>
         <Flex justify="space-between" alignItems="center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,7 @@ const Header = (props: BoxProps) => {
       zIndex="banner"
       {...props}
       borderTopWidth={{ base: '4px', sm: '8px' }}
-      borderColor="fuchsia.700"
+      borderColor="primary.700"
     >
       <Container variant="fluid" py={5}>
         <Flex justify="space-between" alignItems="center">
@@ -26,14 +26,14 @@ const Header = (props: BoxProps) => {
               borderBottomWidth={4}
               borderBottomColor="transparent"
               _hover={{
-                borderBottomColor: 'fuchsia.700',
+                borderBottomColor: 'primary.700',
               }}
               _focus={{
                 boxShadow: 'outline',
-                borderBottomColor: 'fuchsia.700',
+                borderBottomColor: 'primary.700',
               }}
               _active={{
-                borderBottomColor: 'fuchsia.900',
+                borderBottomColor: 'primary.900',
               }}
             >
               <HStack spacing={2}>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,12 +6,13 @@ import Header from '~/components/Header'
 
 interface Props {
   children: React.ReactNode
+  pageBgColor?: 'primaryBg' | 'secondaryBg'
 }
 
-const Layout = ({ children }: Props) => (
+const Layout = ({ children, pageBgColor = 'primaryBg' }: Props) => (
   <Flex height="100%" direction="column">
     <Header />
-    <Box as="main" mt={{ base: 4, md: 8 }} flex="1 0 auto">
+    <Box as="main" pt={{ base: 4, md: 8 }} flex="1 0 auto" bgColor={pageBgColor}>
       {children}
     </Box>
     <Footer />

--- a/src/components/ProcessedReleaseChangeDescription.tsx
+++ b/src/components/ProcessedReleaseChangeDescription.tsx
@@ -68,10 +68,20 @@ const RemarkOl = (props: unknown) => (
 const RemarkLi = (props: ListItemProps) => <ListItem {...props} />
 
 const RemarkPre = (props: unknown) => (
-  <Code as="pre" display="block" mb="4" p="3" overflowX="auto" {...props} />
+  <Code
+    as="pre"
+    display="block"
+    bgColor="primaryBg"
+    mb="4"
+    p="3"
+    overflowX="auto"
+    {...props}
+  />
 )
 
-const RemarkCode = (props: unknown) => <Code color="inherit" {...props} />
+const RemarkCode = (props: unknown) => (
+  <Code color="inherit" bgColor="primaryBg" {...props} />
+)
 
 const RemarkBlockquote = (props: unknown) => <BlockQuote mb="2" {...props} />
 

--- a/src/components/ProcessedReleaseChangeDescription.tsx
+++ b/src/components/ProcessedReleaseChangeDescription.tsx
@@ -126,13 +126,13 @@ const ProcessedReleaseChangeDescription = ({
         <>
           <Link isExternal href={processedReleaseChange.html_url}>
             <Tag
-              color="gray.900"
-              size="md"
+              color="secondary.900"
+              size="lg"
               mb={2}
               rounded="full"
-              bgColor="gray.100"
-              _hover={{ bgColor: 'gray.300' }}
-              _active={{ bgColor: 'gray.400', color: 'gray.900' }}
+              bgColor="secondary.200"
+              _hover={{ bgColor: 'secondary.300' }}
+              _active={{ bgColor: 'secondary.200', color: 'secondary.900' }}
             >
               <TagLabel>{getReleaseVersion(processedReleaseChange)}</TagLabel>
             </Tag>

--- a/src/components/RepositoryReleasesChangelog.tsx
+++ b/src/components/RepositoryReleasesChangelog.tsx
@@ -51,7 +51,7 @@ const ReleaseChangelogGroup = ({
         <Heading
           as="h2"
           size="xl"
-          bg="white"
+          bgColor="secondaryBg"
           mb={4}
           py={4}
           textTransform={textTransform}

--- a/src/components/RepositoryReleasesComparator.tsx
+++ b/src/components/RepositoryReleasesComparator.tsx
@@ -1,4 +1,4 @@
-import { Container, Divider, Flex, Text } from '@chakra-ui/react'
+import { Box, Container, Divider, Flex, Text } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
 import * as React from 'react'
 
@@ -23,36 +23,38 @@ const RepositoryReleasesComparator = () => {
       <Container variant="fluid">
         <RepositoriesComparatorFilters />
       </Container>
-      <Divider my={4} />
-      {repository && (
-        <>
-          <RepositoryReleasesChangelogHeading
-            repository={repository}
-            fromVersion={fromVersion ?? undefined}
-            toVersion={toVersion ?? undefined}
-          />
-          <Container variant="fluid">
-            <RepositoryReleasesChangelog
+      <Divider mt={4} />
+      <Box bgColor="secondaryBg" pt={2} minHeight="full">
+        {repository && (
+          <>
+            <RepositoryReleasesChangelogHeading
               repository={repository}
               fromVersion={fromVersion ?? undefined}
               toVersion={toVersion ?? undefined}
             />
-          </Container>
-        </>
-      )}
+            <Container variant="fluid">
+              <RepositoryReleasesChangelog
+                repository={repository}
+                fromVersion={fromVersion ?? undefined}
+                toVersion={toVersion ?? undefined}
+              />
+            </Container>
+          </>
+        )}
 
-      {/* This is rendered only in CS since SSR doesn't have info about auth user yet */}
-      {isClientSide && !repository && !isAuth && (
-        <Container variant="fluid">
-          <Flex alignItems="center" flexDirection="column">
-            <Text mb={4}>
-              You can increase the max number of allowed requests to GitHub by
-              authorizing the app
-            </Text>
-            <GitHubLoginButton />
-          </Flex>
-        </Container>
-      )}
+        {/* This is rendered only in CS since SSR doesn't have info about auth user yet */}
+        {isClientSide && !repository && !isAuth && (
+          <Container variant="fluid">
+            <Flex alignItems="center" flexDirection="column">
+              <Text mb={4}>
+                You can increase the max number of allowed requests to GitHub by
+                authorizing the app
+              </Text>
+              <GitHubLoginButton />
+            </Flex>
+          </Container>
+        )}
+      </Box>
     </>
   )
 }

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -3,45 +3,11 @@ import { extendTheme, withDefaultColorScheme } from '@chakra-ui/react'
 import { mode } from '@chakra-ui/theme-tools'
 import type { Dict } from '@chakra-ui/utils'
 
-// ***** Legacy colorscheme *****
-
-// The old primaryColor palette will be replaced with a suitable hue out of the Fuchsia TailwindCSS color palette.
-
-const primaryColor: Partial<ColorHues> = {
-  '50': '#ffe8ff',
-  '100': '#efc2f0',
-  '200': '#e09ce3',
-  '300': '#d375d7',
-  '400': '#c54fca',
-  '500': '#ac35b0',
-  '600': '#87288a',
-  '700': '#601c63',
-  '800': '#3b0f3d',
-  '900': '#180319',
-}
-
-// The old blueColor palette will be replaced with a suitable hue out of the Sky TailwindCSS color palette.
-
-const blueColor: Partial<ColorHues> = {
-  '50': '#def8ff',
-  '100': '#b8e6f7',
-  '200': '#90d4ee',
-  '300': '#66c3e5',
-  '400': '#3fb2dd',
-  '500': '#2898c4',
-  '600': '#1a7699',
-  '700': '#0c556e',
-  '800': '#003445',
-  '900': '#00131b',
-}
-
-// ***** New colorscheme *****
-
-// The coolGray palette contains all the shades of gray we'll use in the app.
-// Example uses: body text, headings, changelog text, page background.
-// https://tailwindcss.com/docs/customizing-colors#color-palette-reference
-
-const coolGray: Partial<ColorHues> = {
+/**
+ * The coolGray palette contains all the shades of gray we'll use in the app.
+ * Example uses: body text, headings, changelog text, page background.
+ */
+const coolGray: ColorHues = {
   '50': '#F9FAFB',
   '100': '#F3F4F6',
   '200': '#E5E7EB',
@@ -54,11 +20,11 @@ const coolGray: Partial<ColorHues> = {
   '900': '#111827',
 }
 
-// The Fuchsia palette is our primary accent.
-// Example uses: call to action button, primary action button.
-// https://tailwindcss.com/docs/customizing-colors#color-palette-reference
-
-const fuchsia: Partial<ColorHues> = {
+/**
+ * The Fuchsia palette is our primary accent.
+ * Example uses: call-to-action button, primary action button.
+ */
+const fuchsia: ColorHues = {
   '50': '#FDF4FF',
   '100': '#FAE8FF',
   '200': '#F5D0FE',
@@ -71,11 +37,11 @@ const fuchsia: Partial<ColorHues> = {
   '900': '#701A75',
 }
 
-// The Sky palette is our secondary accent.
-// Example uses: secondary button, version badge.
-// https://tailwindcss.com/docs/customizing-colors#color-palette-reference
-
-const sky: Partial<ColorHues> = {
+/**
+ * The Sky palette is our secondary accent.
+ * Example uses: secondary button, version badge.
+ */
+const sky: ColorHues = {
   '50': '#F0F9FF',
   '100': '#E0F2FE',
   '200': '#BAE6FD',
@@ -92,15 +58,13 @@ const sky: Partial<ColorHues> = {
 // Do NOT use for text that goes on a colored background.
 // Text on colored backgrounds should use a suitable hue from the background color scheme.
 
-const primaryTextLightmode = coolGray['900']
-const secondaryTextLightmode = coolGray['700']
-const tertiaryTextLightmode = coolGray['600']
+const primaryTextLightMode = coolGray['900']
+const secondaryTextLightMode = coolGray['700']
+const tertiaryTextLightMode = coolGray['600']
 
-const primaryTextDarkmode = coolGray['50']
-const secondaryTextDarkmode = coolGray['300']
-const tertiaryTextDarkmode = coolGray['400']
-
-// ***** Collect constants, put them in a customTheme *****
+const primaryTextDarkMode = coolGray['50']
+const secondaryTextDarkMode = coolGray['300']
+const tertiaryTextDarkMode = coolGray['400']
 
 const themeConfig: ThemeConfig = {
   useSystemColorMode: !!process.env.NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE,
@@ -109,18 +73,15 @@ const themeConfig: ThemeConfig = {
 const customTheme = extendTheme(
   {
     colors: {
-      blue: blueColor,
-      primary: primaryColor,
-      secondary: blueColor,
-      coolGray,
-      fuchsia,
-      sky,
-      primaryTextLightmode,
-      secondaryTextLightmode,
-      tertiaryTextLightmode,
-      primaryTextDarkmode,
-      secondaryTextDarkmode,
-      tertiaryTextDarkmode,
+      primary: fuchsia,
+      secondary: sky,
+      gray: coolGray,
+      primaryTextLightMode,
+      secondaryTextLightMode,
+      tertiaryTextLightMode,
+      primaryTextDarkMode,
+      secondaryTextDarkMode,
+      tertiaryTextDarkMode,
     },
     fonts: {
       heading: '"Inter", sans-serif;',

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -76,15 +76,21 @@ const customTheme = extendTheme(
       primary: fuchsia,
       secondary: sky,
       gray: coolGray,
-      primaryTextLightMode,
-      secondaryTextLightMode,
-      tertiaryTextLightMode,
-      primaryTextDarkMode,
-      secondaryTextDarkMode,
-      tertiaryTextDarkMode,
     },
     semanticTokens: {
       colors: {
+        primaryText: {
+          default: primaryTextLightMode,
+          _dark: primaryTextDarkMode,
+        },
+        secondaryText: {
+          default: secondaryTextLightMode,
+          _dark: secondaryTextDarkMode,
+        },
+        tertiaryText: {
+          default: tertiaryTextLightMode,
+          _dark: tertiaryTextDarkMode,
+        },
         primaryBg: {
           default: 'gray.50',
           _dark: 'gray.900',

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -97,7 +97,7 @@ const customTheme = extendTheme(
     components: {
       Link: {
         baseStyle: (props: Dict) => {
-          return { color: mode('fuchsia.700', 'fuchsia.400')(props) }
+          return { color: mode('primary.700', 'primary.400')(props) }
         },
       },
       Button: {
@@ -111,14 +111,14 @@ const customTheme = extendTheme(
               size: 'lg',
               boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',
               borderRadius: '2xl',
-              bg: mode('fuchsia.900', 'fuchsia.200')(props),
-              color: mode('fuchsia.50', 'fuchsia.900')(props),
+              bg: mode('primary.900', 'primary.200')(props),
+              color: mode('primary.50', 'primary.900')(props),
               _hover: {
-                bg: mode('fuchsia.700', 'fuchsia.100')(props),
+                bg: mode('primary.700', 'primary.100')(props),
                 cursor: 'pointer',
               },
               _active: {
-                bg: mode('fuchsia.900', 'fuchsia.200')(props),
+                bg: mode('primary.900', 'primary.200')(props),
                 boxShadow: '0px 2px 2px rgba(0, 0, 0, 0.25) !important',
               },
             }

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -83,6 +83,18 @@ const customTheme = extendTheme(
       secondaryTextDarkMode,
       tertiaryTextDarkMode,
     },
+    semanticTokens: {
+      colors: {
+        primaryBg: {
+          default: 'gray.50',
+          _dark: 'gray.900',
+        },
+        secondaryBg: {
+          default: 'gray.100',
+          _dark: 'gray.800',
+        },
+      },
+    },
     fonts: {
       heading: '"Inter", sans-serif;',
       body: '"Inter", sans-serif;',

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -151,13 +151,13 @@ const customTheme = extendTheme(
               boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',
               borderRadius: '2xl',
               bg: mode('fuchsia.900', 'fuchsia.200')(props),
-              color: mode('white', 'fuchsia.900')(props),
+              color: mode('fuchsia.50', 'fuchsia.900')(props),
               _hover: {
                 bg: mode('fuchsia.700', 'fuchsia.100')(props),
                 cursor: 'pointer',
               },
               _active: {
-                bg: mode('fuchsia.800', 'fuchsia.200')(props),
+                bg: mode('fuchsia.900', 'fuchsia.200')(props),
                 boxShadow: '0px 2px 2px rgba(0, 0, 0, 0.25) !important',
               },
             }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -31,7 +31,7 @@ const Custom404 = () => (
           >
             <Heading
               as="h2"
-              color="primaryTextLightmode"
+              color="primaryText"
               fontSize="4xl"
               fontWeight="black"
               letterSpacing="tight"
@@ -40,7 +40,7 @@ const Custom404 = () => (
             </Heading>
             <Text
               as="p"
-              color="secondaryTextLightmode"
+              color="secondaryText"
               fontSize="2xl"
               fontWeight="black"
             >

--- a/src/pages/comparator.tsx
+++ b/src/pages/comparator.tsx
@@ -5,7 +5,7 @@ import RepositoryReleasesComparator from '~/components/RepositoryReleasesCompara
 import { ComparatorProvider } from '~/contexts/comparator-context'
 
 const ComparatorPage = () => (
-  <Layout>
+  <Layout pageBgColor="secondaryBg">
     <NextSeo title="Comparator" />
     <ComparatorProvider>
       <RepositoryReleasesComparator />

--- a/src/pages/comparator.tsx
+++ b/src/pages/comparator.tsx
@@ -5,7 +5,7 @@ import RepositoryReleasesComparator from '~/components/RepositoryReleasesCompara
 import { ComparatorProvider } from '~/contexts/comparator-context'
 
 const ComparatorPage = () => (
-  <Layout pageBgColor="secondaryBg">
+  <Layout>
     <NextSeo title="Comparator" />
     <ComparatorProvider>
       <RepositoryReleasesComparator />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,6 @@ import {
   VStack,
   Text,
   Container,
-  useColorModeValue,
 } from '@chakra-ui/react'
 import { NextSeo } from 'next-seo'
 import Image from 'next/image'
@@ -64,18 +63,16 @@ const MainSection = () => (
 )
 
 const HomePage = () => {
-  const pageBgColor = useColorModeValue('gray.50', 'gray.900')
-
   return (
     <Layout>
       <NextSeo />
-      <Box mt={-8} py={{ base: 8, lg: 16 }} bgColor={pageBgColor}>
+      <Box mt={-8} py={{ base: 8, lg: 16 }}>
         <Container variant="fluid">
           <MainSection />
         </Container>
       </Box>
 
-      <Box bg="gray.50">
+      <Box>
         <Container variant="fluid">
           <VStack spacing={8} alignItems="left" py="20" px="10">
             <Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -42,7 +42,7 @@ const MainSection = () => (
     >
       <Heading
         as="h2"
-        color="gray.900"
+        color="primaryText"
         fontSize="4xl"
         fontWeight="black"
         textAlign={{ base: 'center', lg: 'left' }}
@@ -80,13 +80,13 @@ const HomePage = () => {
                 as="h3"
                 fontSize="3xl"
                 mb="4"
-                color="primaryTextLightmode"
+                color="primaryText"
                 fontWeight="black"
                 id="features"
               >
                 Features
               </Heading>
-              <List fontSize="" color="secondaryTextLightmode" spacing="4">
+              <List fontSize="" color="secondaryText" spacing="4">
                 <ListItem d="flex">
                   <ListIcon
                     as={HiOutlineSwitchHorizontal}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,7 +43,7 @@ const MainSection = () => (
     >
       <Heading
         as="h2"
-        color={{ base: 'gray.900' }}
+        color="gray.900"
         fontSize="4xl"
         fontWeight="black"
         textAlign={{ base: 'center', lg: 'left' }}
@@ -93,24 +93,36 @@ const HomePage = () => {
                 <ListItem d="flex">
                   <ListIcon
                     as={HiOutlineSwitchHorizontal}
-                    color="sky.700"
+                    color="secondary.700"
                     boxSize={6}
                   />
                   Search repositories and pick a version range
                 </ListItem>
                 <ListItem d="flex">
-                  <ListIcon as={HiOutlineFilter} color="sky.700" boxSize={6} />
+                  <ListIcon
+                    as={HiOutlineFilter}
+                    color="secondary.700"
+                    boxSize={6}
+                  />
                   <Box>
                     Sort and group releases changelogs following{' '}
                     <Link href="https://semver.org/">Semantic Versioning</Link>
                   </Box>
                 </ListItem>
                 <ListItem d="flex">
-                  <ListIcon as={HiOutlineShare} color="sky.700" boxSize={6} />
+                  <ListIcon
+                    as={HiOutlineShare}
+                    color="secondary.700"
+                    boxSize={6}
+                  />
                   Share changelogs comparison with others by giving them a link
                 </ListItem>
                 <ListItem d="flex">
-                  <ListIcon as={HiOutlineTag} color="sky.700" boxSize={6} />
+                  <ListIcon
+                    as={HiOutlineTag}
+                    color="secondary.700"
+                    boxSize={6}
+                  />
                   <Box>
                     Normalize changes categories (e.g. put{' '}
                     <Text as="em">bug fixes</Text> and{' '}
@@ -120,13 +132,17 @@ const HomePage = () => {
                 <ListItem d="flex">
                   <ListIcon
                     as={HiOutlineDocumentSearch}
-                    color="sky.700"
+                    color="secondary.700"
                     boxSize={6}
                   />
                   Highlight code blocks syntax and GitHub references
                 </ListItem>
                 <ListItem d="flex">
-                  <ListIcon as={HiOutlineFire} color="sky.700" boxSize={6} />
+                  <ListIcon
+                    as={HiOutlineFire}
+                    color="secondary.700"
+                    boxSize={6}
+                  />
                   Makes it easy to spot which version introduced specific
                   changes
                 </ListItem>


### PR DESCRIPTION
## Changes

- address pending feedback from #645:
  - cta button text should be `fuchsia.50` in light mode
  - cta button bg color should be default colors on active state
- replace deprecated colors with new colors
- use branding tokens (e.g. `primary` rather than `fuchsia`)
- add semantic tokens for text and background colors
- use semantic tokens

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Closes #243, #244 and #270

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
