### PR TITLE
Images improvements

### DIFF
--- a/cypress/integration/404.spec.ts
+++ b/cypress/integration/404.spec.ts
@@ -11,9 +11,11 @@ it('should display custom 404 page when not found', () => {
     'exist'
   )
 
-  cy.findByAltText(/A purple octopus reading a crystal ball/i)
-    .should('have.attr', 'src')
-    .and('contain', 'mascot-icon')
+  cy.findByRole('main').within(() => {
+    cy.findByRole('img')
+      .should('have.attr', 'src')
+      .and('contain', 'mascot-icon')
+  })
 
   cy.findByRole('link', { name: /go to comparator/i }).click()
   cy.url().should('equal', `${Cypress.config().baseUrl}/comparator`)

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -15,10 +15,6 @@ it('should display corresponding information', () => {
     name: 'Compare GitHub changelogs across multiple releases',
   }).should('exist')
 
-  cy.findByAltText(/A purple octopus reading a crystal ball/i)
-    .should('have.attr', 'src')
-    .should('include', 'mascot-logo')
-
   cy.findByRole('heading', {
     level: 3,
     name: 'Features',

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -15,6 +15,12 @@ it('should display corresponding information', () => {
     name: 'Compare GitHub changelogs across multiple releases',
   }).should('exist')
 
+  cy.findByRole('main').within(() => {
+    cy.findByRole('img')
+      .should('have.attr', 'src')
+      .and('contain', 'mascot-logo')
+  })
+
   cy.findByRole('heading', {
     level: 3,
     name: 'Features',

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,14 +38,7 @@ const Header = (props: BoxProps) => {
             >
               <HStack spacing={2}>
                 <Box h={LOGO_SIZES} w={LOGO_SIZES}>
-                  <Image
-                    priority
-                    src={mascotIcon}
-                    alt=""
-                    placeholder="blur"
-                    height={150}
-                    width={150}
-                  />
+                  <Image src={mascotIcon} alt="" height={150} width={150} />
                 </Box>
                 <Heading
                   as="h1"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,7 +11,7 @@ interface Props {
 const Layout = ({ children }: Props) => (
   <Flex height="100%" direction="column">
     <Header />
-    <Box mt={{ base: 4, md: 8 }} flex="1 0 auto">
+    <Box as="main" mt={{ base: 4, md: 8 }} flex="1 0 auto">
       {children}
     </Box>
     <Footer />

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -21,14 +21,7 @@ const Custom404 = () => (
     <Box pb={{ base: 8, lg: 16 }} align="center">
       <Container variant="fluid">
         <VStack px="10">
-          <Image
-            src={mascotIcon}
-            alt="A purple octopus reading a crystal ball"
-            placeholder="blur"
-            priority
-            width={250}
-            height={250}
-          />
+          <Image src={mascotIcon} alt="" width={250} height={250} />
           <Stack
             shouldWrapChildren
             alignItems="center"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -59,12 +59,7 @@ const MainSection = () => (
         </NextLink>
       </Flex>
     </Stack>
-    <Image
-      priority
-      src={mascotLogo}
-      alt="A purple octopus reading a crystal ball"
-      quality={100}
-    />
+    <Image src={mascotLogo} alt="" quality={100} />
   </Stack>
 )
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,7 +64,6 @@ const MainSection = () => (
       src={mascotLogo}
       alt="A purple octopus reading a crystal ball"
       quality={100}
-      placeholder="blur"
     />
   </Stack>
 )


### PR DESCRIPTION
## Changes

- remove placeholders for our images
- remove unnecessary `alt` for decorative logos
- lazy-load our images

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

I've implemented these improvements after a chat with @trotzig about how to avoid spurious diffs in Happo screenshots. We were generating placeholders for our images, but this was doing more harm than good. Since they are small enough to avoid loading a placeholder first we can benefit from
- loading the actual image faster for the user (so we avoid loading the placeholder, then switching to the actual image)
- avoiding spurious images by having constant images

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
