### PR TITLE
Upgrade framer-motion to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@sentry/nextjs": "6.19.6",
         "downshift": "6.1.7",
         "focus-visible": "5.2.0",
-        "framer-motion": "5.6.0",
+        "framer-motion": "6.3.0",
         "lodash-es": "4.17.21",
         "next": "12.1.4",
         "next-seo": "5.4.0",
@@ -6715,11 +6715,6 @@
       "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==",
       "dev": true
     },
-    "node_modules/debounce": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -8413,15 +8408,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.6.0.tgz",
-      "integrity": "sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.3.0.tgz",
+      "integrity": "sha512-Nm6l2cemuFeSC1fmq9R32sCQs1eplOuZ3r14/PxRDewpE3NUr+ul5ulGRRzk8K0Aa5p76Tedi3sfCUaTPa5fRg==",
       "dependencies": {
         "framesync": "6.0.1",
         "hey-listen": "^1.0.8",
         "popmotion": "11.0.3",
-        "react-merge-refs": "^1.1.0",
-        "react-use-measure": "^2.1.1",
         "style-value-types": "5.0.0",
         "tslib": "^2.1.0"
       },
@@ -8429,18 +8422,8 @@
         "@emotion/is-prop-valid": "^0.8.2"
       },
       "peerDependencies": {
-        "@react-three/fiber": "*",
-        "react": ">=16.8 || ^17.0.0",
-        "react-dom": ">=16.8 || ^17.0.0",
-        "three": "^0.135.0"
-      },
-      "peerDependenciesMeta": {
-        "@react-three/fiber": {
-          "optional": true
-        },
-        "three": {
-          "optional": true
-        }
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
@@ -15252,15 +15235,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-merge-refs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
-      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
     "node_modules/react-query": {
       "version": "3.34.19",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.19.tgz",
@@ -15367,18 +15341,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/react-use-measure": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
-      "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
-      "dependencies": {
-        "debounce": "^1.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.13",
-        "react-dom": ">=16.13"
-      }
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -23143,11 +23105,6 @@
       "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==",
       "dev": true
     },
-    "debounce": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
-    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24422,16 +24379,14 @@
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "framer-motion": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.6.0.tgz",
-      "integrity": "sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.3.0.tgz",
+      "integrity": "sha512-Nm6l2cemuFeSC1fmq9R32sCQs1eplOuZ3r14/PxRDewpE3NUr+ul5ulGRRzk8K0Aa5p76Tedi3sfCUaTPa5fRg==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "framesync": "6.0.1",
         "hey-listen": "^1.0.8",
         "popmotion": "11.0.3",
-        "react-merge-refs": "^1.1.0",
-        "react-use-measure": "^2.1.1",
         "style-value-types": "5.0.0",
         "tslib": "^2.1.0"
       },
@@ -29429,11 +29384,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "react-merge-refs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
-      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
-    },
     "react-query": {
       "version": "3.34.19",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.19.tgz",
@@ -29494,14 +29444,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
-      }
-    },
-    "react-use-measure": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
-      "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
-      "requires": {
-        "debounce": "^1.2.1"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@sentry/nextjs": "6.19.6",
     "downshift": "6.1.7",
     "focus-visible": "5.2.0",
-    "framer-motion": "5.6.0",
+    "framer-motion": "6.3.0",
     "lodash-es": "4.17.21",
     "next": "12.1.4",
     "next-seo": "5.4.0",


### PR DESCRIPTION
## Changes

- Upgrade framer-motion to v6

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

We prevented renovate to upgrade framer-motion to v6 since it wasn't compatible with chakra-ui, but it is compatible now.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
