### PR TITLE
chore: major updates from npm need approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,12 @@
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns": ["eslint", "prettier"],
       "automerge": true
+    },
+    {
+      "description": "Major updates for npm packages require Dependency Dashboard approval",
+      "matchUpdateTypes": ["major"],
+      "matchManagers": ["npm"],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
## Changes

- Require Dependency Dashboard approval for major `npm` package updates

## Context

This helps to reduce the noise until the Chakra UI monorepo bug can be fixed.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [x] Testing manually
