### PR TITLE
Revert "chore: major updates from npm need approval"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,12 +21,6 @@
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns": ["eslint", "prettier"],
       "automerge": true
-    },
-    {
-      "description": "Major updates for npm packages require Dependency Dashboard approval",
-      "matchUpdateTypes": ["major"],
-      "matchManagers": ["npm"],
-      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
Reverts octoclairvoyant/octoclairvoyant-webapp#936

Renovate bot has been fixed in version `32.64.5`, so we _should_ no longer need this.

We should now get a PR with the title:

> Update chakra-ui monorepo to v2 (major)

Because the version is in the PR title, the PR is no longer 👻 immortal, which means we can close it, and it will stay closed. 😉 