### PR TITLE
Rewrite selectors for 404 page failing test

### DIFF
--- a/cypress/integration/404.spec.ts
+++ b/cypress/integration/404.spec.ts
@@ -17,11 +17,11 @@ it('should display custom 404 page when not found', () => {
       .and('contain', 'mascot-icon')
   })
 
-  cy.findByRole('link', { name: /go to comparator/i }).click()
+  cy.contains('Go to comparator').click()
   cy.url().should('equal', `${Cypress.config().baseUrl}/comparator`)
 
   cy.go('back')
 
-  cy.findByRole('link', { name: 'Or go to homepage' }).click()
+  cy.contains('Or go to homepage').click()
   cy.url().should('equal', `${Cypress.config().baseUrl}/`)
 })


### PR DESCRIPTION
## Changes

- Use `contains` instead of `findByRole`

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Fixes #982

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [X] Adding new tests or adjusting existing tests
- [ ] Testing manually
