### PR TITLE
Optimize bundle for modern browsers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,10 @@ import { withSentryConfig } from '@sentry/nextjs'
  * @type {import('next').NextConfig}
  **/
 const config = {
+  experimental: {
+    browsersListForSwc: true,
+    legacyBrowsers: false,
+  },
   swcMinify: true,
   async redirects() {
     return [


### PR DESCRIPTION
## Changes

- Use experimental features from Next.js `12.2.0`

## Context

Quote from [Next.js blog post, Other Improvements](https://nextjs.org/blog/next-12-2#other-improvements):

> We've added experimental support for shipping only modern JavaScript by modifying `browsersList`. You can opt-into this behavior by setting `browsersListForSwc: true` and `legacyBrowsers: false` in the `experimental` option of `next.config.js`.

Fixes #983.

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [x] Testing manually
