### PR TITLE
Add pnpm-lock.yaml to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 package-lock.json
+pnpm-lock.yaml
 .next
 public


### PR DESCRIPTION
## Changes

- Add `pnpm-lock.yaml` to `.prettierignore`

## Context

Our **CI / Format Check (pull_request)** test is failing because Prettier complains about the formatting of the pnpm lock file.

This PR adds that lock file to the list of files that Prettier should ignore.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [x] Testing manually
