### PR TITLE
Limit Renovate updates for pnpm to once a month

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns": ["eslint", "prettier"],
       "automerge": true
-    }
+    },
+    {
+      "description": "Get pnpm updates once a month",
+      "matchPackageNames": ["pnpm"],
+      "extends": ["schedule:monthly"]
+    },
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
     },
     {
       "description": "Get pnpm updates once a month",
+      "matchDepTypes": ["packageManager"],
       "matchPackageNames": ["pnpm"],
       "extends": ["schedule:monthly"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,6 @@
       "matchDepTypes": ["packageManager"],
       "matchPackageNames": ["pnpm"],
       "extends": ["schedule:monthly"]
-    },
+    }
   ]
 }


### PR DESCRIPTION
## Changes

- Limit `pnpm` updates to once a month

## Context

As requested in: https://github.com/octoclairvoyant/octoclairvoyant-webapp/pull/1072#pullrequestreview-1068582567.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
- [x] Not tested
