### PR TITLE
Enabling TS ESLint advanced configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,16 +2,10 @@
 const jestVersion = require('jest/package.json').version
 
 module.exports = {
-	parserOptions: {
-		tsconfigRootDir: __dirname,
-		project: ['./tsconfig.eslint.json'],
-	},
 	extends: [
 		'eslint:recommended',
 		'next/core-web-vitals',
 		'plugin:@typescript-eslint/recommended',
-		'plugin:@typescript-eslint/recommended-requiring-type-checking',
-		'plugin:@typescript-eslint/strict',
 		'prettier',
 	],
 	plugins: ['unicorn'],
@@ -54,6 +48,19 @@ module.exports = {
 		// TypeScript
 		{
 			files: ['**/*.ts?(x)'],
+			parserOptions: {
+				tsconfigRootDir: __dirname,
+				project: ['./tsconfig.eslint.json'],
+			},
+
+			/*
+			 * Linting with Type Information only for TS files:
+			 * https://typescript-eslint.io/docs/linting/typed-linting/#i-get-errors-telling-me-the-file-must-be-included-in-at-least-one-of-the-projects-provided
+			 */
+			extends: [
+				'plugin:@typescript-eslint/recommended-requiring-type-checking',
+				'plugin:@typescript-eslint/strict',
+			],
 			rules: {
 				'@typescript-eslint/array-type': [
 					'warn',
@@ -63,6 +70,15 @@ module.exports = {
 				],
 				'@typescript-eslint/consistent-type-exports': 'error',
 				'@typescript-eslint/consistent-type-imports': 'error',
+
+				// Disabling because of index errors on interfaces,
+				// which works fine in type aliases:
+				// https://bobbyhadz.com/blog/typescript-index-signature-for-type-is-missing-in-type
+				'@typescript-eslint/consistent-type-definitions': 'off',
+
+				// Disabling because it's too strict:
+				// we are interested in using || operator multiple times to avoid empty strings.
+				'@typescript-eslint/prefer-nullish-coalescing': 'off',
 			},
 		},
 		// Jest

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,17 +55,14 @@ module.exports = {
 		{
 			files: ['**/*.ts?(x)'],
 			rules: {
-				'@typescript-eslint/explicit-module-boundary-types': 'off',
 				'@typescript-eslint/array-type': [
-					'error',
+					'warn',
 					{
 						default: 'generic',
 					},
 				],
-				'@typescript-eslint/no-floating-promises': 'error',
 				'@typescript-eslint/consistent-type-exports': 'error',
 				'@typescript-eslint/consistent-type-imports': 'error',
-				'@typescript-eslint/no-explicit-any': 'error',
 			},
 		},
 		// Jest

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,16 @@
 const jestVersion = require('jest/package.json').version
 
 module.exports = {
+	parserOptions: {
+		tsconfigRootDir: __dirname,
+		project: ['./tsconfig.eslint.json'],
+	},
 	extends: [
 		'eslint:recommended',
 		'next/core-web-vitals',
 		'plugin:@typescript-eslint/recommended',
+		'plugin:@typescript-eslint/recommended-requiring-type-checking',
+		'plugin:@typescript-eslint/strict',
 		'prettier',
 	],
 	plugins: ['unicorn'],
@@ -48,9 +54,6 @@ module.exports = {
 		// TypeScript
 		{
 			files: ['**/*.ts?(x)'],
-			parserOptions: {
-				project: ['./tsconfig.lint.json'],
-			},
 			rules: {
 				'@typescript-eslint/explicit-module-boundary-types': 'off',
 				'@typescript-eslint/array-type': [

--- a/additional.d.ts
+++ b/additional.d.ts
@@ -1,1 +1,10 @@
 // declare here any additional module with no types
+
+declare module 'happo-cypress/task' {
+	interface HappoTask {
+		register: (on: Cypress.PluginEvents) => void
+	}
+
+	const happoTask: HappoTask
+	export default happoTask
+}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,4 @@
 import { defineConfig } from 'cypress'
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import happoTask from 'happo-cypress/task'
 
 export default defineConfig({

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -82,5 +82,5 @@ it('should have a working link to comparator page', () => {
 
 	cy.findByRole('link', { name: 'Try me now!' }).click()
 
-	cy.url().should('equal', `${Cypress.config().baseUrl}/comparator`)
+	cy.url().should('equal', `${Cypress.config().baseUrl ?? ''}/comparator`)
 })

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -82,5 +82,5 @@ it('should have a working link to comparator page', () => {
 
 	cy.findByRole('link', { name: 'Try me now!' }).click()
 
-	cy.url().should('equal', `${Cypress.config().baseUrl ?? ''}/comparator`)
+	cy.url().should('equal', `${Cypress.config().baseUrl || ''}/comparator`)
 })

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -18,8 +18,9 @@ import './commands'
 
 // Set GitHub token for all tests
 before(() => {
-	const githubTestingAccessToken =
+	const githubTestingAccessToken = String(
 		Cypress.env('GITHUB_TESTING_ACCESS_TOKEN') || ''
+	)
 	cy.setCookie(GITHUB_STORAGE_KEY, githubTestingAccessToken)
 })
 Cypress.Cookies.defaults({ preserve: GITHUB_STORAGE_KEY })

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"type-check": "tsc --project tsconfig.validation.json",
 		"type-check:cypress": "tsc --project cypress/tsconfig.json",
 		"lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0 --report-unused-disable-directives",
-		"lint:fix": "pnpm lint -- fix",
+		"lint:fix": "pnpm lint --fix",
 		"prettier-base": "prettier . --ignore-unknown --cache --loglevel warn",
 		"format": "pnpm prettier-base --write",
 		"format:check": "pnpm prettier-base --check",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,7 @@ const Footer = ({ bgColor = 'background2' }: FooterProps) => {
 							aria-label="Powered by Vercel"
 							isExternal
 						>
-							<Image alt="" src={poweredByVercelLogo} />
+							<Image alt="" src={poweredByVercelLogo as string} />
 						</Link>
 					</Box>
 				</VStack>

--- a/src/contexts/comparator-context.tsx
+++ b/src/contexts/comparator-context.tsx
@@ -109,7 +109,7 @@ const ComparatorProvider = ({ children }: { children: ReactNode }) => {
 
 				const repositoryQueryParams = mapStringToRepositoryQueryParams(repo)
 
-				if (repositoryQueryParams) {
+				if (repositoryQueryParams.repo && repositoryQueryParams.owner) {
 					const response = await octokit.repos.get(repositoryQueryParams)
 
 					setRepository(response.data)

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -1,4 +1,4 @@
-import type { ColorHues, ThemeConfig } from '@chakra-ui/react'
+import type { ColorHues, ThemeConfig, Theme } from '@chakra-ui/react'
 import { extendTheme, withDefaultColorScheme } from '@chakra-ui/react'
 import { mode } from '@chakra-ui/theme-tools'
 import type { Dict } from '@chakra-ui/utils'
@@ -197,6 +197,6 @@ const customTheme = extendTheme(
 		colorScheme: 'gray',
 		components: ['Code', 'BlockQuote'],
 	})
-)
+) as Theme
 
 export default customTheme

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -69,7 +69,7 @@ export async function obtainAccessToken(
 		throw new Error('Something went wrong obtaining access token')
 	}
 
-	const responseJson: { access_token: string } = await response.json()
+	const responseJson = (await response.json()) as { access_token: string }
 	return responseJson.access_token
 }
 

--- a/src/hooks/useProcessReleases.ts
+++ b/src/hooks/useProcessReleases.ts
@@ -15,7 +15,7 @@ function insertReleaseInGroup(
 	groupedReleases: ProcessedReleasesCollection
 ): void {
 	const { title } = newProcessedRelease
-	if (groupedReleases[title]) {
+	if (Array.isArray(groupedReleases[title])) {
 		// Group already exists, then append new changes of same type
 		groupedReleases[title].push(newProcessedRelease)
 	} else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ export function mapRepositoryToQueryParams(
 	repository?: Repository
 ): RepositoryQueryParams {
 	return {
-		owner: repository?.owner?.login ?? '',
+		owner: repository?.owner.login ?? '',
 		repo: repository?.name ?? '',
 	}
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,13 +3,22 @@
 
 Inspired by official solution #1:
 https://docs.cypress.io/guides/tooling/typescript-support#Clashing-types-with-Jest
+
+Also suggested by TypeScript ESLint (the last option):
+https://typescript-eslint.io/docs/linting/typed-linting/#i-get-errors-telling-me-the-file-must-be-included-in-at-least-one-of-the-projects-provided
 */
 
 {
 	"extends": "./tsconfig.json",
 	// Include al TS files in the project, not just the ones inside src/
 	// so cypress/ ones are linted.
-	"include": ["next-env.d.ts", "additional.d.ts", "**/*.ts", "**/*.tsx"],
+	"include": [
+		".eslintrc.js",
+		"next-env.d.ts",
+		"additional.d.ts",
+		"**/*.ts",
+		"**/*.tsx"
+	],
 
 	// Avoid excluding testing files for linting
 	"exclude": []

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,9 +3,6 @@
 
 Inspired by official solution #1:
 https://docs.cypress.io/guides/tooling/typescript-support#Clashing-types-with-Jest
-
-Also suggested by TypeScript ESLint (the last option):
-https://typescript-eslint.io/docs/linting/typed-linting/#i-get-errors-telling-me-the-file-must-be-included-in-at-least-one-of-the-projects-provided
 */
 
 {


### PR DESCRIPTION
## Changes

- Enabling TS ESLint advanced configs
- Fixing new errors reported

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

I realized TS ESLint provides some advanced configs: [recommended rules requiring type checking](https://typescript-eslint.io/docs/linting/configs#recommended-requiring-type-checking), and [strict rules](https://typescript-eslint.io/docs/linting/configs#strict).

I've enabled both, disabling some specific rules and fixing new errors reported.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
