### PR TITLE
Improve INP with React v18 and Suspense

### DIFF
--- a/src/components/ReleaseVersionsRangeFormControl.tsx
+++ b/src/components/ReleaseVersionsRangeFormControl.tsx
@@ -41,7 +41,7 @@ const ReleaseVersionsRangeFormControl = (props: StackProps) => {
 	const { repository, fromVersion, toVersion } = useComparatorState()
 	const { setFromVersion, setToVersion } = useComparatorUpdater()
 
-	const { data: releases, isLoading } = useReleasesQuery({
+	const { data: releases, isFetching } = useReleasesQuery({
 		repository,
 		fromVersion,
 		toVersion,
@@ -59,8 +59,8 @@ const ReleaseVersionsRangeFormControl = (props: StackProps) => {
 			<ReleaseVersionFormControl
 				label="Select from release"
 				id="from-version"
-				isDisabled={!releases || isLoading}
-				isLoading={isLoading}
+				isDisabled={!releases || isFetching}
+				isLoading={isFetching}
 				placeholder={selectPlaceholder}
 				options={fromReleases}
 				value={fromVersion ?? undefined}
@@ -69,8 +69,8 @@ const ReleaseVersionsRangeFormControl = (props: StackProps) => {
 			<ReleaseVersionFormControl
 				label="Select to release"
 				id="to-version"
-				isDisabled={!releases || isLoading}
-				isLoading={isLoading}
+				isDisabled={!releases || isFetching}
+				isLoading={isFetching}
 				placeholder={selectPlaceholder}
 				options={toReleases}
 				value={toVersion ?? undefined}

--- a/src/components/RepositoryReleasesComparator.tsx
+++ b/src/components/RepositoryReleasesComparator.tsx
@@ -1,6 +1,6 @@
 import { Box, Container, Divider, Flex, Text } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
-import * as React from 'react'
+import { Suspense } from 'react'
 
 import GitHubLoginButton from '~/components/GitHubLoginButton'
 import RepositoriesComparatorFilters from '~/components/RepositoriesComparatorFilters'
@@ -10,7 +10,8 @@ import { useGithubAuth } from '~/contexts/github-auth-provider'
 import useIsClientSide from '~/hooks/useIsClientSide'
 
 const RepositoryReleasesChangelog = dynamic(
-	async () => import('~/components/RepositoryReleasesChangelog')
+	() => import('~/components/RepositoryReleasesChangelog'),
+	{ suspense: true }
 )
 
 const RepositoryReleasesComparator = () => {
@@ -35,11 +36,13 @@ const RepositoryReleasesComparator = () => {
 							toVersion={toVersion ?? undefined}
 						/>
 						<Container variant="fluid">
-							<RepositoryReleasesChangelog
-								repository={repository}
-								fromVersion={fromVersion ?? undefined}
-								toVersion={toVersion ?? undefined}
-							/>
+							<Suspense fallback={<div />}>
+								<RepositoryReleasesChangelog
+									repository={repository}
+									fromVersion={fromVersion ?? undefined}
+									toVersion={toVersion ?? undefined}
+								/>
+							</Suspense>
 						</Container>
 					</>
 				)}

--- a/src/pages/comparator.tsx
+++ b/src/pages/comparator.tsx
@@ -1,14 +1,22 @@
 import { NextSeo } from 'next-seo'
+import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
+
+const RepositoryReleasesComparator = dynamic(
+	() => import('~/components/RepositoryReleasesComparator'),
+	{ suspense: true }
+)
 
 import Layout from '~/components/Layout'
-import RepositoryReleasesComparator from '~/components/RepositoryReleasesComparator'
 import { ComparatorProvider } from '~/contexts/comparator-context'
 
 const ComparatorPage = () => (
 	<Layout pageBgColor="background3">
 		<NextSeo title="Comparator" />
 		<ComparatorProvider>
-			<RepositoryReleasesComparator />
+			<Suspense fallback={<div />}>
+				<RepositoryReleasesComparator />
+			</Suspense>
 		</ComparatorProvider>
 	</Layout>
 )


### PR DESCRIPTION
## Changes

- Wrapping some sections in the comparator page within Suspense
- Fix the "Loading..." indicator in the release version selects

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Trying to improve the Total Blocking Time (TBT) with React v18 and Suspense, based on [Next.js post](https://vercel.com/blog/improving-interaction-to-next-paint-with-react-18-and-suspense).


## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
