### PR TITLE
Consider "latest" as fetched for the `toVersion`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,12 @@ module.exports = {
 			},
 		},
 		// Cypress
-		{ files: ['cypress/**/*.[jt]s'], extends: ['plugin:cypress/recommended'] },
+		{
+			files: ['cypress/**/*.[jt]s'],
+			extends: ['plugin:cypress/recommended'],
+			rules: {
+				'jest/no-focused-tests': 'error',
+			},
+		},
 	],
 }

--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -113,6 +113,8 @@ it('should show changelog results when loading the comparator preloaded with "la
 	cy.findByRole('heading', { level: 2, name: /features/i })
 	cy.findByRole('heading', { level: 2, name: /bug fixes/i })
 
+	cy.findByText(/Don't queue microtasks after condition is met/)
+
 	cy.get('body').happoScreenshot({
 		component: 'Comparator page: preloaded with "latest"',
 	})

--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -23,7 +23,7 @@ it('should have a working form interface', () => {
 
 it('should show expected results when using standard query string', () => {
 	cy.visit(
-		'/?repo=testing-library%2Fdom-testing-library&from=v6.16.0&to=v8.1.0'
+		'/comparator?repo=testing-library%2Fdom-testing-library&from=v6.16.0&to=v8.1.0'
 	)
 
 	cy.wait(10000) // eslint-disable-line cypress/no-unnecessary-waiting
@@ -100,7 +100,7 @@ it('should show expected results when using standard query string', () => {
 
 it('should show changelog results when loading the comparator preloaded with "latest"', () => {
 	cy.visit(
-		'/?repo=testing-library%2Fdom-testing-library&from=v8.11.0&to=latest'
+		'/comparator?repo=testing-library%2Fdom-testing-library&from=v8.11.0&to=latest'
 	)
 
 	cy.findByRole('link', { name: 'dom-testing-library' }).should(

--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -97,3 +97,23 @@ it('should show expected results when using standard query string', () => {
 
 	cy.get('body').happoScreenshot({ component: 'Comparator page: full example' })
 })
+
+it('should show changelog results when loading the comparator preloaded with "latest"', () => {
+	cy.visit(
+		'/?repo=testing-library%2Fdom-testing-library&from=v8.11.0&to=latest'
+	)
+
+	cy.findByRole('link', { name: 'dom-testing-library' }).should(
+		'have.attr',
+		'href',
+		'https://github.com/testing-library/dom-testing-library'
+	)
+	cy.findByRole('heading', { name: 'Changes from v8.11.0 to latest' })
+
+	cy.findByRole('heading', { level: 2, name: /features/i })
+	cy.findByRole('heading', { level: 2, name: /bug fixes/i })
+
+	cy.get('body').happoScreenshot({
+		component: 'Comparator page: preloaded with "latest"',
+	})
+})

--- a/src/queries/release.tsx
+++ b/src/queries/release.tsx
@@ -52,7 +52,9 @@ function useReleasesQuery(
 					!hasFromVersion ||
 					semver.gte(fromVersion, lastReleaseFetched.tag_name)
 				const isToReleaseFetched =
-					!hasToVersion || semver.gte(toVersion, lastReleaseFetched.tag_name)
+					!hasToVersion ||
+					toVersion === 'latest' ||
+					semver.gte(toVersion, lastReleaseFetched.tag_name)
 
 				if (
 					isMaxAutoPaginationReached &&


### PR DESCRIPTION
## Changes

- Considering "latest" as fetched for the `toVersion`

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Fixes #924 

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [X] Adding new tests or adjusting existing tests
- [X] Testing manually (accessing to the review environment with `/comparator?repo=renovatebot%2Frenovate&from=32.52.2&to=latest` appended to the URL)
