### PR TITLE
Group development dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
 	"extends": [
 		"config:base",
 		"helpers:pinGitHubActionDigests",
-		":automergeTypes"
+		":automergeTypes",
+		"npm:unpublishSafe"
 	],
 	"prCreation": "not-pending",
 	"lockFileMaintenance": {
@@ -12,21 +13,26 @@
 	"internalChecksFilter": "strict",
 	"packageRules": [
 		{
-			"description": "Wait 3 days before creating a npm update PR",
-			"matchDatasources": ["npm"],
-			"stabilityDays": 3
-		},
-		{
-			"description": "Automerge ESLint and Prettier updates",
+			"description": [
+				"Group all non-major yarn development dependencies together, get updates once a month"
+			],
+			"matchManagers": ["npm"],
 			"matchDepTypes": ["devDependencies"],
-			"matchPackagePatterns": ["eslint", "prettier"],
-			"automerge": true
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "devDependencies (non-major)",
+			"extends": ["schedule:monthly"]
 		},
 		{
 			"description": "Get pnpm updates once a month",
 			"matchDepTypes": ["packageManager"],
 			"matchPackageNames": ["pnpm"],
 			"extends": ["schedule:monthly"]
+		},
+		{
+			"description": "Automerge ESLint and Prettier updates",
+			"matchDepTypes": ["devDependencies"],
+			"matchPackagePatterns": ["eslint", "prettier"],
+			"automerge": true
 		}
 	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
 	"packageRules": [
 		{
 			"description": [
-				"Group all non-major yarn development dependencies together, get updates once a month"
+				"Group all non-major pnpm development dependencies together, get updates once a month"
 			],
 			"matchManagers": ["npm"],
 			"matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Changes

- Use the `npm:unpublishSafe` preset instead of having our own custom `packageRule`
- Group all development dependencies, and update them once a month
- Order the `packageRules` by importance

## Context

The `packageRules` config option docs say:

> Important to know: Renovate will evaluate all `packageRules` and not stop once it gets a first match. You should order your `packageRules` in order of importance so that later rules can override settings from earlier rules if needed.

Closes #673.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
- [x] Code review