### PR TITLE
Replace status:* labels with adding issues to projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug
-labels: ['bug', 'status:requirements']
+labels: ['bug']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/chore_record.yml
+++ b/.github/ISSUE_TEMPLATE/chore_record.yml
@@ -1,0 +1,41 @@
+name: Chore record
+description: Record an internal change
+labels: ['chore']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Changes that affect the build system, CI config or other changes that don't modify src/test files
+
+  - type: textarea
+    id: what-internal-change-would-you-like-to-have
+    attributes:
+      label: What internal change would you like to have?
+      placeholder: Describe the change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-problem-will-this-change-solve
+    attributes:
+      label: What problem will this change solve?
+      placeholder: Explain how the new change will make things better/easier.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: do-you-want-to-help-make-the-feature
+    attributes:
+      label: Do you want to help make the feature?
+      options:
+        - 'Yes'
+        - 'No'
+    validations:
+      required: true
+
+  - type: textarea
+    id: is-there-anything-else-we-need-to-know
+    attributes:
+      label: Is there anything else we need to know?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore_record.yml
+++ b/.github/ISSUE_TEMPLATE/chore_record.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Changes that affect the build system, CI config or other changes that don't modify src/test files
+        Changes that affect the build system, CI config or other changes that don't modify src/test files.
 
   - type: textarea
     id: what-internal-change-would-you-like-to-have

--- a/.github/ISSUE_TEMPLATE/feature_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/feature_suggestion.yml
@@ -1,6 +1,6 @@
 name: Feature suggestion
 description: Suggest a new feature
-labels: ['enhancement', 'status:requirements']
+labels: ['enhancement']
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,19 @@
+name: Add to project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add labeled issues to general project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@0.3.0
+        with:
+          project-url: https://github.com/orgs/octoclairvoyant/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: bug, enhancement, chore
+          label-operator: OR


### PR DESCRIPTION
## Changes

- Remove `status:*` labels
- Add a new issue template for "chore" type
- Set up [add-to-project](https://github.com/actions/add-to-project) action, so issues created from templates get automatically added to the [General Project](https://github.com/orgs/octoclairvoyant/projects/2).

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Closes #1106
Closes #1079 

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually (I need to test it after this gets merged by creating a fake issue and checking it gets added to the project)
