### PR TITLE
Enable Cypress retries

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -13,5 +13,8 @@ export default defineConfig({
 			happoTask.register(on)
 		},
 		baseUrl: 'http://localhost:3000',
+		retries: {
+			runMode: 1,
+		},
 	},
 })


### PR DESCRIPTION
## Changes

- Set retries to 1 attempt only in `run` mode

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Closes #1130

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
