### PR TITLE
Fix lodash-es package usage

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,16 +1,24 @@
 import type { Config } from 'jest'
 import nextJest from 'next/jest'
+import { pathsToModuleNameMapper } from 'ts-jest'
+
+import { compilerOptions } from './tsconfig.json'
 
 const createJestConfig = nextJest({
 	dir: './',
 })
 
+const tsPathsToModules = pathsToModuleNameMapper(compilerOptions.paths, {
+	prefix: '<rootDir>/',
+})
+
 const config: Config = {
+	preset: 'ts-jest',
 	clearMocks: true,
 	roots: ['<rootDir>/src/'],
 	reporters: ['default', 'github-actions'],
 	moduleNameMapper: {
-		'~/(.*)': '<rootDir>/src/$1',
+		...tsPathsToModules,
 		'^lodash-es$': 'lodash', // so lodash-es is not compiled
 	},
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,12 +7,10 @@ const createJestConfig = nextJest({
 
 const config: Config = {
 	clearMocks: true,
-	rootDir: './src',
+	roots: ['<rootDir>/src/'],
 	reporters: ['default', 'github-actions'],
-	coverageDirectory: '<rootDir>/../coverage',
-	moduleDirectories: ['node_modules', '<rootDir>/'],
 	moduleNameMapper: {
-		'~/(.*)': '<rootDir>/$1',
+		'~/(.*)': '<rootDir>/src/$1',
 	},
 }
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
 	reporters: ['default', 'github-actions'],
 	moduleNameMapper: {
 		'~/(.*)': '<rootDir>/src/$1',
+		'^lodash-es$': 'lodash', // so lodash-es is not compiled
 	},
 }
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const nextJest = require('next/jest')
+import type { Config } from 'jest'
+import nextJest from 'next/jest'
 
 const createJestConfig = nextJest({
 	dir: './',
 })
 
-/** @type {import('@jest/types').Config.InitialOptions} */
-const config = {
+const config: Config = {
 	clearMocks: true,
 	rootDir: './src',
 	reporters: ['default', 'github-actions'],
@@ -17,4 +16,4 @@ const config = {
 	},
 }
 
-module.exports = createJestConfig(config)
+export default createJestConfig(config)

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
 		"lint-staged": "13.0.3",
 		"prettier": "2.7.1",
 		"start-server-and-test": "1.14.0",
+		"ts-jest": "29.0.0-next.1",
 		"type-fest": "2.18.0",
 		"typescript": "4.7.4"
 	},

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@octokit/openapi-types": "13.0.1",
 		"@testing-library/cypress": "8.0.3",
 		"@types/happo-cypress": "3.0.1",
-		"@types/lodash": "4.14.182",
+		"@types/lodash-es": "4.17.6",
 		"@types/mdast": "3.0.10",
 		"@types/node": "16.11.47",
 		"@types/react": "18.0.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ specifiers:
   '@tanstack/react-query-devtools': 4.2.3
   '@testing-library/cypress': 8.0.3
   '@types/happo-cypress': 3.0.1
-  '@types/lodash': 4.14.182
+  '@types/lodash-es': 4.17.6
   '@types/mdast': 3.0.10
   '@types/node': 16.11.47
   '@types/react': 18.0.17
@@ -101,7 +101,7 @@ devDependencies:
   '@octokit/openapi-types': 13.0.1
   '@testing-library/cypress': 8.0.3_cypress@10.6.0
   '@types/happo-cypress': 3.0.1
-  '@types/lodash': 4.14.182
+  '@types/lodash-es': 4.17.6
   '@types/mdast': 3.0.10
   '@types/node': 16.11.47
   '@types/react': 18.0.17
@@ -3867,6 +3867,12 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 16.11.47
+    dev: true
+
+  /@types/lodash-es/4.17.6:
+    resolution: {integrity: sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==}
+    dependencies:
+      '@types/lodash': 4.14.182
     dev: true
 
   /@types/lodash.mergewith/4.6.6:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,7 @@ specifiers:
   remark-stringify: 10.0.2
   semver: 7.3.7
   start-server-and-test: 1.14.0
+  ts-jest: 29.0.0-next.1
   type-fest: 2.18.0
   typescript: 4.7.4
   unified: 10.1.2
@@ -127,6 +128,7 @@ devDependencies:
   lint-staged: 13.0.3
   prettier: 2.7.1
   start-server-and-test: 1.14.0
+  ts-jest: 29.0.0-next.1_zfkv7lnhphqhiwok24yl3yclem
   type-fest: 2.18.0
   typescript: 4.7.4
 
@@ -4918,6 +4920,13 @@ packages:
       node-releases: 2.0.6
       update-browserslist-db: 1.0.5_browserslist@4.21.3
 
+  /bs-logger/0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+    dev: true
+
   /bser/2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
@@ -8506,6 +8515,10 @@ packages:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
     dev: true
 
+  /lodash.memoize/4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+    dev: true
+
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -11011,6 +11024,40 @@ packages:
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
+
+  /ts-jest/29.0.0-next.1_zfkv7lnhphqhiwok24yl3yclem:
+    resolution: {integrity: sha512-bVo2GDuJiV+cWEYB72tdz2Ips4JDKa04bcKikPULxxUHT4fsoY1zB2zvsrJym18qrFpXyVrIdgJFLfEx2YTkbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.13
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.0.1_@types+node@16.11.47
+      jest-util: 29.0.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.7.4
+      yargs-parser: 21.1.1
+    dev: true
 
   /ts-node/10.9.1_h7xq4gp5ydsyq7ojing3noryx4:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}

--- a/src/components/RepositorySearchCombobox.tsx
+++ b/src/components/RepositorySearchCombobox.tsx
@@ -14,7 +14,7 @@ import {
 	Text,
 } from '@chakra-ui/react'
 import { useCombobox } from 'downshift'
-import debounce from 'lodash/debounce'
+import { debounce } from 'lodash-es'
 import * as React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { HiArrowDown, HiArrowUp } from 'react-icons/hi'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import lowerCase from 'lodash/lowerCase'
+import { lowerCase } from 'lodash-es'
 import type { Content } from 'mdast'
 import * as semver from 'semver'
 


### PR DESCRIPTION
## Changes

- Installing correct types (`@types/lodash-es`)
- Replacing incorrect lodash imports
- Updating jest config to avoid compiling lodash-es
- Simplifying jest config

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

It turns out the lodash types installed were incorrect: the project was using `lodash-es` but using `@types/lodash` instead of `@types/lodash-es`.

This has been solved now, updating jest config to avoid the  `SyntaxError: Unexpected token 'export'` error for ESM packages.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [X] Adding new tests or adjusting existing tests
- [ ] Testing manually
