### PR TITLE
Remove MSW from production bundle

### DIFF
--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -1,4 +1,4 @@
-const DEFAULT_COMMAND_TIMEOUT = Cypress.config('defaultCommandTimeout') 
+const DEFAULT_COMMAND_TIMEOUT = Cypress.config('defaultCommandTimeout')
 const DOUBLE_COMMAND_TIMEOUT = DEFAULT_COMMAND_TIMEOUT * 2
 // Increase the command timeout since it takes a while for findBy queries
 // to find certain elements while the comparator is still processing the changelog.
@@ -225,7 +225,6 @@ it('should show changelog results when preloading from URL with more than 10 rel
 
 	// Wait a bit before checking the rendered release changelog details
 	// since this may take a while to appear.
-	// eslint-disable-next-line cypress/no-unnecessary-waiting
 	cy.wait(DOUBLE_COMMAND_TIMEOUT)
 
 	cy.findByRole('heading', {

--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -1,4 +1,5 @@
-const DOUBLE_COMMAND_TIMEOUT = Cypress.config('defaultCommandTimeout') * 2
+const DEFAULT_COMMAND_TIMEOUT = Cypress.config('defaultCommandTimeout') 
+const DOUBLE_COMMAND_TIMEOUT = DEFAULT_COMMAND_TIMEOUT * 2
 // Increase the command timeout since it takes a while for findBy queries
 // to find certain elements while the comparator is still processing the changelog.
 Cypress.config('defaultCommandTimeout', DOUBLE_COMMAND_TIMEOUT)
@@ -180,6 +181,10 @@ it('should show changelog results when preloading from URL with "latest"', () =>
  * last one must not be requested since all the info will be available by then.
  */
 it('should show changelog results when preloading from URL with more than 10 release pages', () => {
+	// There are tons of changelogs to process in this test,
+	// so it will take a while to render the result.
+	Cypress.config('defaultCommandTimeout', DEFAULT_COMMAND_TIMEOUT * 3)
+
 	cy.visit('/comparator?repo=renovatebot%2Frenovate&from=26.9.0&to=32.172.2')
 
 	// This is necessary because an early request is triggered from preloaded URL.
@@ -221,7 +226,7 @@ it('should show changelog results when preloading from URL with more than 10 rel
 	// Wait a bit before checking the rendered release changelog details
 	// since this may take a while to appear.
 	// eslint-disable-next-line cypress/no-unnecessary-waiting
-	cy.wait(5000)
+	cy.wait(DOUBLE_COMMAND_TIMEOUT)
 
 	cy.findByRole('heading', {
 		name: 'Changes from 26.9.0 to 32.172.2',

--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -1,5 +1,4 @@
 const DOUBLE_COMMAND_TIMEOUT = Cypress.config('defaultCommandTimeout') * 2
-const TRIPLE_COMMAND_TIMEOUT = Cypress.config('defaultCommandTimeout') * 3
 // Increase the command timeout since it takes a while for findBy queries
 // to find certain elements while the comparator is still processing the changelog.
 Cypress.config('defaultCommandTimeout', DOUBLE_COMMAND_TIMEOUT)
@@ -219,42 +218,24 @@ it('should show changelog results when preloading from URL with more than 10 rel
 		)
 	})
 
-	// The following elements may take a while to appear since the comparator
-	// has to fetch several pages and process a bunch of releases, so we increase
-	// the timeout.
+	// Wait a bit before checking the rendered release changelog details
+	// since this may take a while to appear.
+	// eslint-disable-next-line cypress/no-unnecessary-waiting
+	cy.wait(2000)
+
 	cy.findByRole('heading', {
 		name: 'Changes from 26.9.0 to 32.172.2',
-		timeout: TRIPLE_COMMAND_TIMEOUT,
 	})
-	cy.findByRole('heading', {
-		level: 2,
-		name: /breaking changes/i,
-		timeout: TRIPLE_COMMAND_TIMEOUT,
-	})
-	cy.findByRole('heading', {
-		level: 2,
-		name: /bug fixes/i,
-		timeout: TRIPLE_COMMAND_TIMEOUT,
-	})
-	cy.findByRole('heading', {
-		level: 2,
-		name: /features/i,
-		timeout: TRIPLE_COMMAND_TIMEOUT,
-	})
-	cy.findByRole('heading', {
-		level: 2,
-		name: /reverts/i,
-		timeout: TRIPLE_COMMAND_TIMEOUT,
-	})
-	cy.findByRole('heading', {
-		level: 2,
-		name: /miscellaneous chores/i,
-		timeout: TRIPLE_COMMAND_TIMEOUT,
-	})
+	cy.findByRole('heading', { level: 2, name: /breaking changes/i })
+	cy.findByRole('heading', { level: 2, name: /bug fixes/i })
+	cy.findByRole('heading', { level: 2, name: /features/i })
+	cy.findByRole('heading', { level: 2, name: /reverts/i })
+	cy.findByRole('heading', { level: 2, name: /miscellaneous chores/i })
+	cy.findByRole('heading', { level: 2, name: /build system/i })
+
 	// link for 26.9.1 release (lowest one)
 	cy.findByRole('link', {
 		name: '26.9.1',
-		timeout: TRIPLE_COMMAND_TIMEOUT,
 	}).should(
 		'have.attr',
 		'href',
@@ -263,7 +244,6 @@ it('should show changelog results when preloading from URL with more than 10 rel
 	// link for 32.172.2 release (highest one)
 	cy.findAllByRole('link', {
 		name: '32.172.2',
-		timeout: TRIPLE_COMMAND_TIMEOUT,
 	}).should(
 		'have.attr',
 		'href',

--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -221,7 +221,7 @@ it('should show changelog results when preloading from URL with more than 10 rel
 	// Wait a bit before checking the rendered release changelog details
 	// since this may take a while to appear.
 	// eslint-disable-next-line cypress/no-unnecessary-waiting
-	cy.wait(2000)
+	cy.wait(5000)
 
 	cy.findByRole('heading', {
 		name: 'Changes from 26.9.0 to 32.172.2',

--- a/src/hooks/useMsw.ts
+++ b/src/hooks/useMsw.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
-const isApiMockingEnabled = process.env.NEXT_PUBLIC_API_MOCKING === 'enabled'
+const isApiMockingEnabled =
+	process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' || !!process.env.VERCEL
 
 if (typeof window !== 'undefined') {
 	window.isApiMockingEnabled = isApiMockingEnabled

--- a/src/hooks/useMsw.ts
+++ b/src/hooks/useMsw.ts
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react'
 
-import { initMocks } from '~/mock-service-worker'
-
 const isApiMockingEnabled = process.env.NEXT_PUBLIC_API_MOCKING === 'enabled'
 
 if (typeof window !== 'undefined') {
@@ -12,12 +10,13 @@ function setCypressAppReady(): void {
 	window.isApiMockingReady = true
 }
 
-function prepare(): Promise<ServiceWorkerRegistration | undefined> {
+async function prepare(): Promise<ServiceWorkerRegistration | undefined> {
 	if (isApiMockingEnabled) {
+		const { initMocks } = await import('~/mock-service-worker')
 		return initMocks()
 	}
 
-	return Promise.resolve(undefined)
+	return undefined
 }
 
 function initIsReadyState() {

--- a/src/hooks/useMsw.ts
+++ b/src/hooks/useMsw.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 const isApiMockingEnabled =
-	process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' || !!process.env.VERCEL
+	process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' && !process.env.VERCEL
 
 if (typeof window !== 'undefined') {
 	window.isApiMockingEnabled = isApiMockingEnabled


### PR DESCRIPTION
## Changes

- Import MSW utils dynamically within our custom `useMsw` hook
- Add an extra check to force disabling MSW when the app is deployed and running on Vercel

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Fixes #1157

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually

The bundle size has decreased again:
![imagen](https://user-images.githubusercontent.com/2677072/190483164-35ca79ac-81a9-4f51-8569-9a378e3cb14a.png)

