### PR TITLE
ignore MSW in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,50 +11,28 @@
 		"automerge": true
 	},
 	"internalChecksFilter": "strict",
-	"ignoreDeps": [
-		"msw"
-	],
+	"ignoreDeps": ["msw"],
 	"packageRules": [
 		{
 			"description": [
 				"Group all non-major pnpm development dependencies together, get updates once a month"
 			],
-			"matchManagers": [
-				"npm"
-			],
-			"matchDepTypes": [
-				"devDependencies"
-			],
-			"matchUpdateTypes": [
-				"minor",
-				"patch"
-			],
+			"matchManagers": ["npm"],
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
 			"groupName": "devDependencies (non-major)",
-			"extends": [
-				"schedule:monthly"
-			]
+			"extends": ["schedule:monthly"]
 		},
 		{
 			"description": "Get pnpm updates once a month",
-			"matchDepTypes": [
-				"packageManager"
-			],
-			"matchPackageNames": [
-				"pnpm"
-			],
-			"extends": [
-				"schedule:monthly"
-			]
+			"matchDepTypes": ["packageManager"],
+			"matchPackageNames": ["pnpm"],
+			"extends": ["schedule:monthly"]
 		},
 		{
 			"description": "Automerge ESLint and Prettier updates",
-			"matchDepTypes": [
-				"devDependencies"
-			],
-			"matchPackagePatterns": [
-				"eslint",
-				"prettier"
-			],
+			"matchDepTypes": ["devDependencies"],
+			"matchPackagePatterns": ["eslint", "prettier"],
 			"automerge": true
 		}
 	]

--- a/renovate.json
+++ b/renovate.json
@@ -11,27 +11,50 @@
 		"automerge": true
 	},
 	"internalChecksFilter": "strict",
+	"ignoreDeps": [
+		"msw"
+	],
 	"packageRules": [
 		{
 			"description": [
 				"Group all non-major pnpm development dependencies together, get updates once a month"
 			],
-			"matchManagers": ["npm"],
-			"matchDepTypes": ["devDependencies"],
-			"matchUpdateTypes": ["minor", "patch"],
+			"matchManagers": [
+				"npm"
+			],
+			"matchDepTypes": [
+				"devDependencies"
+			],
+			"matchUpdateTypes": [
+				"minor",
+				"patch"
+			],
 			"groupName": "devDependencies (non-major)",
-			"extends": ["schedule:monthly"]
+			"extends": [
+				"schedule:monthly"
+			]
 		},
 		{
 			"description": "Get pnpm updates once a month",
-			"matchDepTypes": ["packageManager"],
-			"matchPackageNames": ["pnpm"],
-			"extends": ["schedule:monthly"]
+			"matchDepTypes": [
+				"packageManager"
+			],
+			"matchPackageNames": [
+				"pnpm"
+			],
+			"extends": [
+				"schedule:monthly"
+			]
 		},
 		{
 			"description": "Automerge ESLint and Prettier updates",
-			"matchDepTypes": ["devDependencies"],
-			"matchPackagePatterns": ["eslint", "prettier"],
+			"matchDepTypes": [
+				"devDependencies"
+			],
+			"matchPackagePatterns": [
+				"eslint",
+				"prettier"
+			],
 			"automerge": true
 		}
 	]


### PR DESCRIPTION
## Changes

- Ignore MSW in Renovate

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

[MSW v0.47.0](https://github.com/mswjs/msw/releases/tag/v0.47.0) introduced exports in package.json which is causing problems with ESM imports. We are fixing MSW version until [this problem is solved](https://github.com/mswjs/msw/issues/1267).

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
