### PR TITLE
ignore msw subdependencies in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
 		"automerge": true
 	},
 	"internalChecksFilter": "strict",
-	"ignoreDeps": ["msw"],
+	"ignoreDeps": ["msw", "headers-polyfill"],
 	"packageRules": [
 		{
 			"description": [


### PR DESCRIPTION
## Changes

- Ignore "headers-polyfill" in renovate

## Context

Related to #1170, MSW subdependencies can't be updated too (same ESM issues).

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
