### PR TITLE
ignore more msw subdeps in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
 		"automerge": true
 	},
 	"internalChecksFilter": "strict",
-	"ignoreDeps": ["msw", "headers-polyfill"],
+	"ignoreDeps": ["msw", "headers-polyfill", "@mswjs/interceptors"],
 	"packageRules": [
 		{
 			"description": [


### PR DESCRIPTION
## Changes

- Ignore `@mswjs/interceptors` in Renovate

## Context

Ignore more MSW subdependencies

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
