### PR TITLE
Use `npm:unpublishSafe` preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
 		"config:base",
 		"helpers:pinGitHubActionDigests",
 		":automergeTypes"
+		"npm:unpublishSafe"
 	],
 	"prCreation": "not-pending",
 	"lockFileMaintenance": {
@@ -11,11 +12,6 @@
 	},
 	"internalChecksFilter": "strict",
 	"packageRules": [
-		{
-			"description": "Wait 3 days before creating a npm update PR",
-			"matchDatasources": ["npm"],
-			"stabilityDays": 3
-		},
 		{
 			"description": "Automerge ESLint and Prettier updates",
 			"matchDepTypes": ["devDependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
 	"extends": [
 		"config:base",
 		"helpers:pinGitHubActionDigests",
-		":automergeTypes"
+		":automergeTypes",
 		"npm:unpublishSafe"
 	],
 	"prCreation": "not-pending",


### PR DESCRIPTION
## Changes

- Use `npm:unpublishSafe` preset [^docs]

## Context

I see you've reverted #1104, which also included this change. I think we should use the preset instead of making our own rule. 😉 

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
- [x] Code inspection only

[^docs]: https://docs.renovatebot.com/presets-npm/#npmunpublishsafe