### PR TITLE
Cache pnpm dependencies properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,27 @@ env:
   CYPRESS_INSTALL_BINARY: 0
 
 jobs:
+  # Putting a first "install" job first, so it saves the pnpm cache for other jobs.
+  install:
+    name: Install dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@9f10b1b9fa56e99e4c5d12c2a085c8a0c37ab0ac # tag=0.10.1
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # tag=v3.5.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
   lint:
     name: Code Linting
+    needs: install
     runs-on: ubuntu-latest
     steps:
       # Arrange
@@ -38,6 +57,7 @@ jobs:
 
   types_check:
     name: Types Check
+    needs: install
     runs-on: ubuntu-latest
     steps:
       # Arrange
@@ -63,6 +83,7 @@ jobs:
 
   format_check:
     name: Format Check
+    needs: install
     runs-on: ubuntu-latest
     steps:
       # Arrange
@@ -86,6 +107,7 @@ jobs:
 
   tests:
     name: JavaScript Tests
+    needs: install
     runs-on: ubuntu-latest
     steps:
       # Arrange

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,8 +20,28 @@ env:
   HAPPO_NONCE: '${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:
+  # Putting a first "install" job first, so it saves the pnpm cache for other jobs.
+  install:
+    name: Install dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@9f10b1b9fa56e99e4c5d12c2a085c8a0c37ab0ac # tag=0.10.1
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # tag=v3.5.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+
   cypress:
     name: Cypress with Happo
+    needs: install
     runs-on: ubuntu-latest
     strategy:
       # when one test fails, DO NOT cancel the other
@@ -76,6 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs:
+      - install
       - cypress
     steps:
       # Arrange


### PR DESCRIPTION
## Changes

- Adds a prior job in CI to install dependencies

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Since all jobs are installing dependencies with pnpm in parallel, they are not able to reuse the cache since only one of them can save it. [See this CI run as an example](https://github.com/octoclairvoyant/octoclairvoyant-webapp/actions/runs/3224811427): the "format check" job was able to save the pnpm cache in "post setup node" step, but none of them were able to restore any cache.

We are going to try mitigating this by adding a prior job which installs the dependencies, then all CI jobs depend on it to take advantage of the generated cache.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
