### PR TITLE
Disable useFullPageFallbackForTallScreenshots in Happo

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -9,15 +9,19 @@ module.exports = {
 	targets: {
 		'Chrome - Desktop': new RemoteBrowserTarget('chrome', {
 			viewport: DESKTOP_VIEWPORT,
+			useFullPageFallbackForTallScreenshots: false,
 		}),
 		'Firefox - Desktop': new RemoteBrowserTarget('firefox', {
 			viewport: DESKTOP_VIEWPORT,
+			useFullPageFallbackForTallScreenshots: false,
 		}),
 		'Chrome - Mobile': new RemoteBrowserTarget('chrome', {
 			viewport: MOBILE_VIEWPORT,
+			useFullPageFallbackForTallScreenshots: false,
 		}),
 		'Safari - Mobile': new RemoteBrowserTarget('safari', {
 			viewport: MOBILE_VIEWPORT,
+			useFullPageFallbackForTallScreenshots: false,
 		}),
 	},
 }


### PR DESCRIPTION
This commit fixes an issue with timeouts coming from Happo when taking screenshots in Safari.

For tall screenshots (over 4000px), Happo will apply a workaround when taking the screenshot to work around quirks that automated browsers apply. It involves taking a full page screenshot and then cropping the screenshot down to the right size. However, in many cases, the cropping will never happen (when you actually want all the content on the page).

In Safari, we've seen this process take longer than 30s. In these cases, a timeout error is thrown which makes the job eventually fail.

More information about the configuration option here: https://docs.happo.io/docs/configuration#target-usefullpagefallbackfortallscreenshots

By setting useFullPageFallbackForTallScreenshots to false, we can disable the full page+cropping behavior. I've verified that this change makes screenshots finish in less than a few seconds. And the screenshot results look the same.

It's likely that this commit will trigger Happo diffs on some screenshots, mostly because the process to generate a hash from the image content is different in the two codepaths.

## Changes

-

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [x] Testing manually
