### PR TITLE
Set custom fonts with next/font

### DIFF
--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -146,9 +146,9 @@ const customTheme = extendTheme(
 			},
 		},
 		fonts: {
-			heading: '"Inter", sans-serif;',
-			body: '"Inter", sans-serif;',
-			mono: '"Roboto Mono", monospace;',
+			heading: 'var(--font-inter)',
+			body: 'var(--font-inter)',
+			mono: 'var(--font-roboto-mono)',
 		},
 		styles: {
 			global: {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { resetIdCounter } from 'downshift'
 import type { AppProps } from 'next/app'
+import { Inter, Roboto_Mono } from 'next/font/google'
 import { DefaultSeo } from 'next-seo'
 
 import VercelAnalytics from '~/components/VercelAnalytics'
@@ -20,11 +21,25 @@ const queryClient = new QueryClient({
 	},
 })
 
+const interFont = Inter({
+	subsets: ['latin'],
+})
+
+const robotoMonoFont = Roboto_Mono({
+	subsets: ['latin'],
+})
+
 const App = ({ Component, pageProps }: AppProps) => {
 	resetIdCounter()
 
 	return (
 		<>
+			<style jsx global>{`
+				:root {
+					--font-inter: ${interFont.style.fontFamily};
+					--font-roboto-mono: ${robotoMonoFont.style.fontFamily};
+				}
+			`}</style>
 			<VercelAnalytics />
 			<DefaultSeo {...DefaultSEO} />
 			<QueryClientProvider client={queryClient}>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -9,14 +9,6 @@ class MyDocument extends Document {
 			<Html lang="en">
 				<Head>
 					<link
-						rel="stylesheet"
-						href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&display=swap"
-					/>
-					<link
-						rel="stylesheet"
-						href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-					/>
-					<link
 						rel="apple-touch-icon"
 						sizes="57x57"
 						href="/favicon/apple-icon-57x57.png"


### PR DESCRIPTION
## Changes

- Stop setting custom fonts through google fonts link in head
- Set custom fonts through `next/font`

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

n/a

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
