### PR TITLE
Use Renovate maintainers's best practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
 	"extends": [
-		"config:base",
-		"helpers:pinGitHubActionDigests",
+		"config:best-practices",
 		":automergeTypes",
 		"npm:unpublishSafe",
 		"helpers:disableTypesNodeMajor"


### PR DESCRIPTION
## Changes

- Use `config:best-practices`
  - Because `config:best-practices` includes `"helpers:pinGitHubActionDigests"` I'm removing that line

## Context

Renovate renamed `config:base` to `config:recommended`.

If you want we can opt-in to use the Renovate maintainer's best practices by using `config:best-practices`.

Before you merge, check the [`config:best-practices` docs](https://docs.renovatebot.com/presets-config/#configbest-practices) to see if you like the behavior:

- Renovate will create config migration PRs to update old terms to new terms
- Renovate pins Docker Digests (new behavior!)
- Renovate pins GitHub Action digests (same as current behavior)
- Renovate pins development depenencies (This is new behavior!)

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
- [x] Code inspection only
