### PR TITLE
Renovate: automerge linters and testers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
 	"extends": [
 		"config:best-practices",
 		":automergeTypes",
+		":automergeLinters",
+		":automergeTesters",
+		":automergeRequireAllStatusChecks",
 		"npm:unpublishSafe",
 		"helpers:disableTypesNodeMajor"
 	],
@@ -13,13 +16,6 @@
 	"internalChecksFilter": "strict",
 	"platformAutomerge": true,
 	"packageRules": [
-		{
-			"description": "Automerge ESLint and Prettier updates once a month",
-			"matchDepTypes": ["devDependencies"],
-			"matchPackagePatterns": ["eslint", "prettier"],
-			"automerge": true,
-			"extends": ["schedule:monthly"]
-		},
 		{
 			"description": "Get pnpm updates once a month",
 			"matchDepTypes": ["packageManager"],


### PR DESCRIPTION
## Changes

- Add linters and testers to be automerged
- Require all status checks before automerge

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

n/a

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [ ] Testing manually
