### PR TITLE
Stop using downshift resetIdCounter

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import { ChakraProvider } from '@chakra-ui/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { resetIdCounter } from 'downshift'
 import type { AppProps } from 'next/app'
 import { Inter, Roboto_Mono } from 'next/font/google'
 import { DefaultSeo } from 'next-seo'
@@ -30,8 +29,6 @@ const robotoMonoFont = Roboto_Mono({
 })
 
 const App = ({ Component, pageProps }: AppProps) => {
-	resetIdCounter()
-
 	return (
 		<>
 			<style jsx global>{`


### PR DESCRIPTION
## Changes

- Stop using `resetIdCounter` from `downshift` ([it's not needed for React v18 or newer](https://github.com/downshift-js/downshift?tab=readme-ov-file#resetidcounter))

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

n/a

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
