### PR TITLE
Replace octokit iterator with fetch method

### DIFF
--- a/src/queries/release.tsx
+++ b/src/queries/release.tsx
@@ -14,8 +14,6 @@ import {
 } from '@/models'
 import { isStableRelease, mapRepositoryToQueryParams } from '@/utils'
 
-type FetchReleasesArgs = RepositoryQueryParams & { page?: number | undefined }
-
 type ReleasesQueryResults = Array<Release>
 type ReleasesQueryParams = {
 	repository?: Repository | null
@@ -29,15 +27,8 @@ type ConfigArg =
 const QUERY_KEY = 'releases'
 const MAX_AUTO_PAGINATION = 10
 
-async function fetchReleases({ owner, repo, page }: FetchReleasesArgs) {
-	const response = await octokit.rest.repos.listReleases({
-		owner,
-		repo,
-		per_page: 100,
-		page,
-	})
-
-	return response.data.filter(isStableRelease)
+function getHasNextPage(link: string): boolean {
+	return link.includes('rel="next"')
 }
 
 function useReleasesQuery(
@@ -48,13 +39,45 @@ function useReleasesQuery(
 		params.repository ?? undefined,
 	)
 	const { fromVersion, toVersion } = params
+	const hasFromVersion = !!fromVersion
+	const hasToVersion = !!toVersion
 
 	return useQuery<ReleasesQueryResults, Error>({
 		queryKey: [QUERY_KEY, finalParams],
 		queryFn: async () => {
 			const { owner, repo } = finalParams
+			const releases: Array<Release> = []
+			let shouldKeepPaginating = true
+			let pagination = 1
 
-			const releases = await fetchReleases({ owner, repo })
+			while (shouldKeepPaginating) {
+				const response = await octokit.rest.repos.listReleases({
+					owner,
+					repo,
+					per_page: 100,
+					page: pagination,
+				})
+				const { data: releasesBatch, headers } = response
+				releases.push(...releasesBatch.filter(isStableRelease))
+
+				pagination++
+				const hasNextPage = !!headers.link && getHasNextPage(headers.link)
+				const isMaxAutoPaginationReached = pagination > MAX_AUTO_PAGINATION
+				const lastReleaseFetched = releasesBatch[releasesBatch.length - 1]
+				const isFromReleaseFetched =
+					!hasFromVersion ||
+					semver.gte(fromVersion, lastReleaseFetched.tag_name)
+				const isToReleaseFetched =
+					!hasToVersion ||
+					toVersion === 'latest' ||
+					semver.gte(toVersion, lastReleaseFetched.tag_name)
+
+				shouldKeepPaginating =
+					hasNextPage &&
+					(!isMaxAutoPaginationReached ||
+						!isFromReleaseFetched ||
+						!isToReleaseFetched)
+			}
 
 			return releases
 		},


### PR DESCRIPTION
## Changes

- Stop using octokit iterator
- Paginates with octokit `listReleases` REST method + while loop

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Closes #1127. This doesn't paginate using a proper React Query hook like `useInfiniteQuery` tho, it just removes the usage of the octokit iterator. The proper infinite query will be addressed in #1129.

## Tests

<!-- We do not accept new features without corresponding automated tests. -->

I've checked my work by:

- [ ] Adding new tests or adjusting existing tests
- [X] Testing manually
